### PR TITLE
Update versions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,11 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 15
         uses: actions/setup-java@v2.5.0
         with:
           distribution: 'temurin'
-          java-version: 1.8
+          java-version: 15
 
       - name: Inject credentials
         run: echo "$CREDENTIALS" >> local.properties

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,11 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 15
+      - name: Set up JDK 11
         uses: actions/setup-java@v2.5.0
         with:
           distribution: 'temurin'
-          java-version: 15
+          java-version: 11
 
       - name: Inject credentials
         run: echo "$CREDENTIALS" >> local.properties

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,20 +9,33 @@ jobs:
       fail-fast: false
       matrix:
         brand: ['vrtnu', 'vtmgo', 'vier']
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2.4.0
         with:
+          fetch-depth: 0
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v2.5.0
+        with:
+          distribution: 'temurin'
           java-version: 1.8
+
       - name: Inject credentials
         run: echo "$CREDENTIALS" >> local.properties
         shell: bash
         env:
           CREDENTIALS: ${{ secrets.CREDENTIALS }}
+
       - name: E2E ${{ matrix.brand }}
-        run: ./gradlew :${{ matrix.brand }}:test -i
-      - uses: actions/upload-artifact@v2
+        uses: gradle/gradle-build-action@v2.1.1
+        with:
+          arguments: :${{ matrix.brand }}:test -i
+
+      - uses: actions/upload-artifact@v2.3.1
         with:
           name: Package
           path: build/libs
+
+      - name: Stop Gradle daemons
+        run: ./gradlew --stop

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.idea/ktfmt.xml

--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KtfmtSettings">
-    <option name="enabled" value="false" />
-  </component>
-</project>

--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KtfmtSettings">
+    <option name="enabled" value="false" />
+  </component>
+</project>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val kotlinVersion = "1.4.31"
+    const val kotlinVersion = "1.6.10"
 }
 
 object Dependencies {
@@ -12,7 +12,7 @@ object Dependencies {
 
     const val okHttp3 = "com.squareup.okhttp3:okhttp:4.9.1"
 
-    private const val arrowVersion = "1.0.0-SNAPSHOT"
+    private const val arrowVersion = "1.0.1"
     const val arrowCore = "io.arrow-kt:arrow-core:${arrowVersion}"
     const val arrowSyntax = "io.arrow-kt:arrow-syntax:${arrowVersion}"
     const val arrowMeta = "io.arrow-kt:arrow-meta:${arrowVersion}"
@@ -21,7 +21,7 @@ object Dependencies {
 
     const val jsoup = "org.jsoup:jsoup:1.13.1"
 
-    private const val coroutineVersion = "1.4.3"
+    private const val coroutineVersion = "1.6.0"
     const val coroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutineVersion}"
 }
 
@@ -31,11 +31,11 @@ object Plugins {
 }
 
 object Testing {
-    private const val kotestVersion = "4.4.3"
+    private const val kotestVersion = "5.1.0"
 
     private const val kotestRunner = "io.kotest:kotest-runner-junit5:${kotestVersion}"
     private const val kotestAssertionsCore = "io.kotest:kotest-assertions-core:${kotestVersion}"
-    private const val kotestAssertionsArrow = "io.kotest:kotest-assertions-arrow:${kotestVersion}"
+    private const val kotestAssertionsArrow = "io.kotest.extensions:kotest-assertions-arrow:1.2.2"
     private const val kotestProperty = "io.kotest:kotest-property:${kotestVersion}"
 
     const val mockk = "io.mockk:mockk:v1.10.2"

--- a/goplay/src/test/java/be/tapped/goplay/content/EpisodeParserTest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/content/EpisodeParserTest.kt
@@ -2,7 +2,7 @@ package be.tapped.goplay.content
 
 import arrow.core.Either
 import be.tapped.goplay.ApiResponse
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 
 public class EpisodeParserTest : StringSpec({

--- a/goplay/src/test/java/be/tapped/goplay/content/GoPlayApiE2ETest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/content/GoPlayApiE2ETest.kt
@@ -22,7 +22,7 @@ public class GoPlayApiE2ETest : FreeSpec({
                 tokens.shouldBeRight()
             }
 
-            val refreshTokens = tokens.orNull()!!.token.refreshToken
+            val refreshTokens = tokens.shouldBeRight().token.refreshToken
             "it should be able to refresh the tokens" - {
                 val newTokens = profileRepo.refreshTokens(refreshTokens)
 
@@ -31,7 +31,7 @@ public class GoPlayApiE2ETest : FreeSpec({
                 }
             }
 
-            val accessToken = tokens.orNull()!!.token.accessToken
+            val accessToken = tokens.shouldBeRight().token.accessToken
             "it should be able to fetch the user attributes" - {
                 val profile = profileRepo.getUserAttributes(accessToken)
 
@@ -46,9 +46,9 @@ public class GoPlayApiE2ETest : FreeSpec({
                     programs.shouldBeRight()
                 }
 
-                val idToken = tokens.orNull()!!.token.idToken
+                val idToken = tokens.shouldBeRight().token.idToken
                 "when fetching episodes" - {
-                    programs.orNull()!!.programs.flatMap(Program::playlists).flatMap(Program.Playlist::episodes).shuffled().take(100).parTraverse {
+                    programs.shouldBeRight().programs.flatMap(Program::playlists).flatMap(Program.Playlist::episodes).shuffled().take(100).parTraverse {
                         val streams = goPlayApi.streamByVideoUuid(idToken, it.videoUuid)
 
                         "it should have found a stream $streams" {
@@ -195,7 +195,7 @@ public class GoPlayApiE2ETest : FreeSpec({
             }
 
             "should have found search hits" {
-                searchResult.orNull()!!.hits.shouldNotBeEmpty()
+                searchResult.shouldBeRight().hits.shouldNotBeEmpty()
             }
 
             val searchKeys = searchResult.orNull()!!.hits.map { it.source.searchKey }

--- a/goplay/src/test/java/be/tapped/goplay/content/GoPlayApiE2ETest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/content/GoPlayApiE2ETest.kt
@@ -3,7 +3,7 @@ package be.tapped.goplay.content
 import arrow.fx.coroutines.parTraverse
 import be.tapped.goplay.CredentialsProvider
 import be.tapped.goplay.profile.HttpProfileRepo
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
 

--- a/goplay/src/test/java/be/tapped/goplay/content/HtmlProgramParserTest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/content/HtmlProgramParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.goplay.content
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 
@@ -9,7 +9,6 @@ public class HtmlProgramParserTest : StringSpec({
     "should be able to parse all programs" {
         val allProgramsHTML = javaClass.classLoader?.getResourceAsStream("programs.html")!!.reader().readText()
         val allPrograms = HtmlProgramParser(JsoupParser()).parse(allProgramsHTML)
-        allPrograms.shouldBeRight()
-        allPrograms.orNull()!!.shouldHaveSize(113)
+        allPrograms.shouldBeRight().shouldHaveSize(113)
     }
 })

--- a/goplay/src/test/java/be/tapped/goplay/content/JsonSearchResultsParserTest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/content/JsonSearchResultsParserTest.kt
@@ -1,5 +1,6 @@
 package be.tapped.goplay.content
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 
@@ -7,7 +8,7 @@ public class JsonSearchResultsParserTest : StringSpec({
 
     "should be able to parse" {
         val searchResultJson = javaClass.classLoader?.getResourceAsStream("search-result.json")!!.reader().readText()
-        val searchResult = JsonSearchResultsParser().parse(searchResultJson).orNull()!!
+        val searchResult = JsonSearchResultsParser().parse(searchResultJson).shouldBeRight()
         searchResult shouldHaveSize 20
     }
 })

--- a/goplay/src/test/java/be/tapped/goplay/epg/EpgRepoTest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/epg/EpgRepoTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.goplay.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import java.util.*
 

--- a/goplay/src/test/java/be/tapped/goplay/epg/JsonEpgParserTest.kt
+++ b/goplay/src/test/java/be/tapped/goplay/epg/JsonEpgParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.goplay.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 
 public class JsonEpgParserTest : StringSpec({

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonCategoryParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonCategoryParserTest.kt
@@ -1,5 +1,6 @@
 package be.tapped.vrtnu.content
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -15,7 +16,7 @@ public class JsonCategoryParserTest : StringSpec() {
     init {
         "should be able to parse" {
             val categoriesJson = javaClass.classLoader?.getResourceAsStream("categories.json")!!.reader().readText()
-            val categories = jsonCategoryParser.parse(categoriesJson).orNull()!!
+            val categories = jsonCategoryParser.parse(categoriesJson).shouldBeRight()
             categories shouldHaveSize 19
             categories.map(Category::name) shouldBe listOf(
                 "met-audiodescriptie",

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonEpisodeParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonEpisodeParserTest.kt
@@ -1,5 +1,6 @@
 package be.tapped.vrtnu.content
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -8,7 +9,7 @@ public class JsonEpisodeParserTest : StringSpec({
 
     "should be able to parse the episodes" {
         val episodeJson = javaClass.classLoader?.getResourceAsStream("episodes.json")!!.reader().readText()
-        val searchResult = JsonSearchHitParser(UrlPrefixMapper()).parse(episodeJson).orNull()!!
+        val searchResult = JsonSearchHitParser(UrlPrefixMapper()).parse(episodeJson).shouldBeRight()
         searchResult.results shouldHaveSize 22
         searchResult.meta shouldBe Meta(22, Pages(1, 1, 150))
         searchResult.facets shouldBe FacetWrapper(

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonProgramParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonProgramParserTest.kt
@@ -1,5 +1,6 @@
 package be.tapped.vrtnu.content
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 
@@ -7,7 +8,7 @@ public class JsonProgramParserTest : StringSpec({
 
     "should be able to parse the programs" {
         val programJson = javaClass.classLoader?.getResourceAsStream("programs.json")!!.reader().readText()
-        val programs = JsonProgramParser(ProgramSanitizer(UrlPrefixMapper())).parse(programJson).orNull()!!
+        val programs = JsonProgramParser(ProgramSanitizer(UrlPrefixMapper())).parse(programJson).shouldBeRight()
         programs shouldHaveSize 495
     }
 })

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonStreamInformationParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/JsonStreamInformationParserTest.kt
@@ -1,7 +1,7 @@
 package be.tapped.vrtnu.content
 
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 
 public class JsonStreamInformationParserTest : StringSpec({
     "should be able to parse the live stream " {

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/VRTApiE2ETest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/VRTApiE2ETest.kt
@@ -31,7 +31,7 @@ public class VRTApiE2ETest : FreeSpec({
             }
 
             "the categories should not be empty"  {
-                categories.orNull()!!.categories.shouldNotBeEmpty()
+                categories.shouldBeRight().categories.shouldNotBeEmpty()
             }
         }
 
@@ -42,7 +42,7 @@ public class VRTApiE2ETest : FreeSpec({
                 azPrograms.shouldBeRight()
             }
 
-            val programs = azPrograms.orNull()!!.programs
+            val programs = azPrograms.shouldBeRight().programs
             "it should not be empty" {
                 programs.shouldNotBeEmpty()
 
@@ -68,7 +68,7 @@ public class VRTApiE2ETest : FreeSpec({
                     }
 
                     "refreshing the tokens by refresh token" - {
-                        val newTokens = profileRepo.refreshTokenWrapper(tokens.orNull()!!.tokenWrapper.refreshToken)
+                        val newTokens = profileRepo.refreshTokenWrapper(tokens.shouldBeRight().tokenWrapper.refreshToken)
                         "it should be successful" {
                             newTokens.shouldBeRight()
                         }
@@ -82,7 +82,7 @@ public class VRTApiE2ETest : FreeSpec({
                         }
 
                         "fetching favorites" - {
-                            val favorites = profileRepo.favorites(xVRTToken.orNull()!!.xVRTToken)
+                            val favorites = profileRepo.favorites(xVRTToken.shouldBeRight().xVRTToken)
 
                             "it should be successful" {
                                 favorites.shouldBeRight()
@@ -90,7 +90,7 @@ public class VRTApiE2ETest : FreeSpec({
                         }
 
                         "fetching a VRT-Player-Token" - {
-                            val vrtPlayerToken = profileRepo.fetchVRTPlayerToken(xVRTToken.orNull()!!.xVRTToken)
+                            val vrtPlayerToken = profileRepo.fetchVRTPlayerToken(xVRTToken.shouldBeRight().xVRTToken)
 
                             "it should be successful" {
                                 vrtPlayerToken.shouldBeRight()
@@ -100,7 +100,7 @@ public class VRTApiE2ETest : FreeSpec({
                                 LiveStreams.allLiveStreams.parTraverse {
                                     "fetching live stream $it" - {
                                         val liveStream = vrtApi.getLiveStream(
-                                                vrtPlayerToken.orNull()!!.vrtPlayerToken, it.videoId
+                                                vrtPlayerToken.shouldBeRight().vrtPlayerToken, it.videoId
                                         )
                                         "it should be successful" {
                                             liveStream.shouldBeRight()
@@ -122,7 +122,7 @@ public class VRTApiE2ETest : FreeSpec({
             }
 
             "the program should not be null" {
-                program.orNull()!!.program shouldNotBe null
+                program.shouldBeRight().program shouldNotBe null
             }
         }
 
@@ -134,7 +134,7 @@ public class VRTApiE2ETest : FreeSpec({
             }
 
             "the program should be null" {
-                nonExistingProgram.orNull()!!.program shouldBe null
+                nonExistingProgram.shouldBeRight().program shouldBe null
             }
         }
 
@@ -162,7 +162,7 @@ public class VRTApiE2ETest : FreeSpec({
             }
 
             "it should have found multiple episodes" {
-                episodes.first().orNull()!!.searchHits.shouldNotBeEmpty()
+                episodes.first().shouldBeRight().searchHits.shouldNotBeEmpty()
             }
         }
 
@@ -175,7 +175,7 @@ public class VRTApiE2ETest : FreeSpec({
             }
 
             "it should have found 1 episode" {
-                episodes.first().orNull()!!.searchHits.shouldHaveSize(1)
+                episodes.first().shouldBeRight().searchHits.shouldHaveSize(1)
             }
         }
     }

--- a/vrtnu/src/test/java/be/tapped/vrtnu/content/VRTApiE2ETest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/content/VRTApiE2ETest.kt
@@ -3,8 +3,8 @@ package be.tapped.vrtnu.content
 import arrow.fx.coroutines.parTraverse
 import be.tapped.vrtnu.CredentialsProvider
 import be.tapped.vrtnu.profile.ProfileRepo
-import io.kotest.assertions.arrow.either.shouldBeLeft
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty

--- a/vrtnu/src/test/java/be/tapped/vrtnu/epg/EpgRepoTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/epg/EpgRepoTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vrtnu.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import java.util.*
 

--- a/vrtnu/src/test/java/be/tapped/vrtnu/epg/JsonEpgParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/epg/JsonEpgParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vrtnu.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 
 public class JsonEpgParserTest : StringSpec({

--- a/vrtnu/src/test/java/be/tapped/vrtnu/profile/JsonFavoriteParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/profile/JsonFavoriteParserTest.kt
@@ -10,8 +10,7 @@ public class JsonFavoriteParserTest : StringSpec({
     "should be able to parse" {
         val favoritesJson = javaClass.classLoader?.getResourceAsStream("favorites.json")!!.reader().readText()
         val favorites = JsonFavoriteParser().parse(favoritesJson)
-        favorites.shouldBeRight()
-        val favoriteWrapper = favorites.orNull()!!
+        val favoriteWrapper = favorites.shouldBeRight()
         favoriteWrapper.size shouldBe 137
         favoriteWrapper.programs shouldBe listOf(
             "vrtnuaz16",

--- a/vrtnu/src/test/java/be/tapped/vrtnu/profile/JsonFavoriteParserTest.kt
+++ b/vrtnu/src/test/java/be/tapped/vrtnu/profile/JsonFavoriteParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vrtnu.profile
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonFavoritesParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonFavoritesParserTest.kt
@@ -1,9 +1,7 @@
 package be.tapped.vtmgo.content
 
 import io.kotest.assertions.arrow.core.shouldBeRight
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
 
 public class JsonFavoritesParserTest : StringSpec({
 

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonFavoritesParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonFavoritesParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.content
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonPagedTeaserContentParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonPagedTeaserContentParserTest.kt
@@ -1,12 +1,13 @@
 package be.tapped.vtmgo.content
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 
 public class JsonPagedTeaserContentParserTest : StringSpec({
     "should be able to parse" {
         val azJson = javaClass.classLoader?.getResourceAsStream("az-programs.json")!!.reader().readText()
-        val azCatalog = JsonPagedTeaserContentParser().parse(azJson).orNull()!!
+        val azCatalog = JsonPagedTeaserContentParser().parse(azJson).shouldBeRight()
         azCatalog shouldHaveSize 564
     }
 })

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonProgramParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonProgramParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.content
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonStoreFrontParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonStoreFrontParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.content
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonStreamResponseParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/JsonStreamResponseParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.content
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 
 public class JsonStreamResponseParserTest : StringSpec() {

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/VTMApiE2ETest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/VTMApiE2ETest.kt
@@ -32,7 +32,7 @@ public class VTMApiE2ETest : FreeSpec() {
                             token.orNull()?.token?.jwt.shouldNotBeNull()
                         }
 
-                        val jwtToken = token.orNull()!!.token.jwt
+                        val jwtToken = token.shouldBeRight().token.jwt
                         val profiles = profileRepo.getProfiles(jwtToken)
 
                         "then it should be successful" {
@@ -40,10 +40,10 @@ public class VTMApiE2ETest : FreeSpec() {
                         }
 
                         "then it should have at least one profile" {
-                            profiles.orNull()!!.profiles.shouldHaveAtLeastSize(1)
+                            profiles.shouldBeRight().profiles.shouldHaveAtLeastSize(1)
                         }
 
-                        profiles.orNull()!!.profiles.parTraverse { profile ->
+                        profiles.shouldBeRight().profiles.parTraverse { profile ->
                             "fetching favorites for $profile" - {
                                 val favorites = vtmApi.fetchMyFavorites(jwtToken, profile)
 
@@ -53,7 +53,7 @@ public class VTMApiE2ETest : FreeSpec() {
                             }
                         }
 
-                        val profile = profiles.orNull()!!.profiles.first()
+                        val profile = profiles.shouldBeRight().profiles.first()
 
                         "and doing a search" - {
                             val searchResults = vtmApi.search(jwtToken, profile, "Code van Coppens")
@@ -78,7 +78,7 @@ public class VTMApiE2ETest : FreeSpec() {
                                 liveChannels.shouldBeRight()
                             }
 
-                            liveChannels.orNull()!!.channels.parTraverse {
+                            liveChannels.shouldBeRight().channels.parTraverse {
                                 "fetching the stream for $it" - {
                                     val liveStream = vtmApi.fetchStream(it)
 
@@ -87,7 +87,7 @@ public class VTMApiE2ETest : FreeSpec() {
                                     }
 
                                     "should be of correct type" {
-                                        liveStream.orNull()!!.stream should beOfType<AnvatoStream.Live>()
+                                        liveStream.shouldBeRight().stream should beOfType<AnvatoStream.Live>()
                                     }
                                 }
                             }
@@ -101,7 +101,7 @@ public class VTMApiE2ETest : FreeSpec() {
                                     storeFronts.shouldBeRight()
                                 }
 
-                                storeFronts.orNull()!!.rows.flatMap { storeFront ->
+                                storeFronts.shouldBeRight().rows.flatMap { storeFront ->
                                     when (storeFront) {
                                         is StoreFront.CarouselStoreFront -> storeFront.teasers.map(CarouselTeaser::target)
                                         is StoreFront.DefaultSwimlaneStoreFront -> storeFront.teasers.map(DefaultSwimlaneTeaser::target)
@@ -141,10 +141,10 @@ public class VTMApiE2ETest : FreeSpec() {
                             }
 
                             "then the list should not be empty" {
-                                azPrograms.orNull()!!.catalog.shouldNotBeEmpty()
+                                azPrograms.shouldBeRight().catalog.shouldNotBeEmpty()
                             }
 
-                            azPrograms.orNull()!!.catalog.map { it.target.asTarget }.filterIsInstance<TargetResponse.Target.Program>().shuffled()
+                            azPrograms.shouldBeRight().catalog.map { it.target.asTarget }.filterIsInstance<TargetResponse.Target.Program>().shuffled()
                                     .take(100).forEach { program ->
                                         "fetching program details with id ${program.id}" - {
                                             val programDetails = vtmApi.fetchProgram(program, jwtToken, profile)

--- a/vtmgo/src/test/java/be/tapped/vtmgo/content/VTMApiE2ETest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/content/VTMApiE2ETest.kt
@@ -3,7 +3,7 @@ package be.tapped.vtmgo.content
 import arrow.fx.coroutines.parTraverse
 import be.tapped.vtmgo.CredentialsProvider
 import be.tapped.vtmgo.profile.HttpAuthenticationRepo
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldNotBeEmpty

--- a/vtmgo/src/test/java/be/tapped/vtmgo/epg/EpgRepoTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/epg/EpgRepoTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import java.util.*
 

--- a/vtmgo/src/test/java/be/tapped/vtmgo/epg/JsonEpgParserTest.kt
+++ b/vtmgo/src/test/java/be/tapped/vtmgo/epg/JsonEpgParserTest.kt
@@ -1,6 +1,6 @@
 package be.tapped.vtmgo.epg
 
-import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 
 public class JsonEpgParserTest : StringSpec({


### PR DESCRIPTION
This PR bumps Kotlin, KotlinX Coroutines, Arrow and Kotest to latest version.
It fixes the breaking changes from Kotest 4.x.x to 5.x.x